### PR TITLE
Change all names to oci-register-machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# This is the Makefile for oci-registerMachine
+# This is the Makefile for oci-register-machine
 # Authors: Sally O'Malley <somalley@redhat.com>
 #
 # Targets (see each target for more information):
@@ -11,26 +11,26 @@
 all: build docs
 
 PREFIX ?= $(DESTDIR)/usr
-HOOKSDIR=/usr/libexec/docker/hooks.d
+HOOKSDIR=/usr/lib/docker/hooks.d
 HOOKSINSTALLDIR=$(DESTDIR)$(HOOKSDIR)
 
 # Build code
 #
 # Example:
 # 	make build
-oci-registerMachine: registerMachine.go
+oci-register-machine: oci-register-machine.go
 
-	go build -v -o oci-registerMachine
+	go build -v -o oci-register-machine
 
-oci-registerMachine.1.gz: oci-registerMachine.1.md
+oci-register-machine.1.gz: oci-register-machine.1.md
 
 	go get github.com/cpuguy83/go-md2man
-	go-md2man -in "oci-registerMachine.1.md" -out "oci-registerMachine.1"
-	sed -i 's|$$HOOKSDIR|$(HOOKSDIR)|' oci-registerMachine.1
-	gzip -f oci-registerMachine.1
+	go-md2man -in "oci-register-machine.1.md" -out "oci-register-machine.1"
+	sed -i 's|$$HOOKSDIR|$(HOOKSDIR)|' oci-register-machine.1
+	gzip -f oci-register-machine.1
 
-docs: oci-registerMachine.1.gz
-build: oci-registerMachine
+docs: oci-register-machine.1.gz
+build: oci-register-machine
 
 # Install code (change here to place anywhere you want)
 #
@@ -38,14 +38,14 @@ build: oci-registerMachine
 #	make install
 install: all
 	install -d -m 0755 $(HOOKSINSTALLDIR)
-	install -m 755 oci-registerMachine $(HOOKSINSTALLDIR)
+	install -m 755 oci-register-machine $(HOOKSINSTALLDIR)
 	install -d -m 0755 $(PREFIX)/share/man/man1
-	install oci-registerMachine.1.gz $(PREFIX)/share/man/man1
+	install oci-register-machine.1.gz $(PREFIX)/share/man/man1
 
 # Clean up
 #
 # Example:
 # 	make clean
 clean:
-	rm oci-registerMachine
-	rm oci-registerMachine.1.gz
+	rm oci-register-machine
+	rm oci-register-machine.1.gz

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ tracks locally running virtual machines and containers and the processes belongi
 
 
 This project produces a golang binary that can be used with Docker (with minor code changes).
-If you clone this branch and build/install `registerMachine.go`, a binary will be placed in
-`/usr/libexec/docker/hooks.d` named `oci-registerMachine`. You can change this location by
+If you clone this branch and build/install `register-machine.go`, a binary will be placed in
+`/usr/libexec/docker/hooks.d` named `oci-register-machine`. You can change this location by
 editing `HOOKSDIR` in the Makefile.
 
 

--- a/oci-register-machine.1.md
+++ b/oci-register-machine.1.md
@@ -1,20 +1,20 @@
-% OCI-REGISTERMACHINE(1) oci-registerMachine
+% OCI-REGISTER-MACHINE(1) oci-register-machine
 % November 2015
 ## NAME
-oci-registerMachine - Register OCI containers with systemd-machined
+oci-register-machine - Register OCI containers with systemd-machined
 
 ## SYNOPSIS
 
-**oci-registerMachine**
+**oci-register-machine**
 
 ## DESCRIPTION
 
-`oci-registerMachine` is a OCI hook program. If you add it to the runc json data
+`oci-register-machine` is a OCI hook program. If you add it to the runc json data
 as a hook, runc will execute the application after the container process is created but before it is executed, with a `prestart` flag.  When the container exits
-`oci-registerMachine` will be executed, after the container exits but before it is destroyed, with the `poststop` flag.  Docker will execute `oci-registerMachine` as a container hook when it is installed in the $HOOKSDIR directory.
+`oci-register-machine` will be executed, after the container exits but before it is destroyed, with the `poststop` flag.  Docker will execute `oci-register-machine` as a container hook when it is installed in the $HOOKSDIR directory.
 
 After starting an OCI container, the container will be listed with the `machinectl`.  The machine name will be the container ID.  Machinectl will then be able
-to manage the container. When container exits, the oci-registerMachine will remove the instance from machinectl.
+to manage the container. When container exits, the oci-register-machine will remove the instance from machinectl.
 
 
 ## EXAMPLES

--- a/oci-register-machine.go
+++ b/oci-register-machine.go
@@ -50,7 +50,6 @@ func RegisterMachine(name string, id string, pid int, root_directory string) err
 	if service == "" {
 		service = "runc"
 	}
-	log.Print("RegisterMachine: objCall")
 	/*	return obj.Call("org.freedesktop.machine1.Manager.RegisterMachine", 0, name[0:32], av, service, "container", uint32(pid), root_directory).Err
 	 */
 	return obj.Call("org.freedesktop.machine1.Manager.RegisterMachine", 0, name[0:32], av, service, "container", uint32(pid), "/").Err
@@ -73,12 +72,11 @@ func TerminateMachine(name string) error {
 
 func main() {
 	var state State
-	logwriter, err := syslog.New(syslog.LOG_NOTICE, "ociRegisterMachine")
+	logwriter, err := syslog.New(syslog.LOG_NOTICE, "oci-register-machine")
 	if err == nil {
 		log.SetOutput(logwriter)
 	}
 	command := os.Args[1]
-	log.Print("oci register machine: ", command)
 	if err := json.NewDecoder(os.Stdin).Decode(&state); err != nil {
 		log.Fatalf("RegisterMachine Failed %v", err.Error())
 	}

--- a/oci-register-machine.spec
+++ b/oci-register-machine.spec
@@ -1,12 +1,12 @@
-%global hooksdir "/usr/libexec/docker/hooks.d"
+%global hooksdir "/usr/lib/docker/hooks.d"
 
-Name:		oci-registerMachine
+Name:		oci-register-machine
 Version:	0.1.0	
 Release:	1%{?dist}
 Summary:	This is the golang binary RPM spec for using systemd-machined service methods RegisterMachine and TerminateMachine.
 License:	GPLv2.1+	
-URL:		https://github.com/sallyom/Register	
-Source0:	https://github.com/sallyom/Register/archive/v%{version}.tar.gz
+URL:		https://github.com/projectatomic/oci-register-machine
+Source0:	https://github.com/projectatomic/oci-register-machine/archive/v%{version}.tar.gz
     
 BuildRequires:  gcc
 BuildRequires:	golang >= 1.2-7
@@ -14,7 +14,7 @@ BuildRequires:  golang-github-godbus-dbus-devel
 BuildRequires:  golang-github-cpuguy83-go-md2man
 
 %description
-oci-registerMachine implements a container manager that makes use of systemd-machined.
+oci-register-machine implements a container manager that makes use of systemd-machined.
 RegisterMachine and TerminateMachine are called using prestart and poststop hooks.
 
 %prep
@@ -22,7 +22,7 @@ RegisterMachine and TerminateMachine are called using prestart and poststop hook
 
 %build
 mkdir -p ./_build/src/github.com/oci
-ln -s $(pwd) ./_build/src/github.com/oci/registerMachine
+ln -s $(pwd) ./_build/src/github.com/oci/register-machine
 make 
 
 %install
@@ -31,9 +31,9 @@ make DESTDIR="%{buildroot}" install
 %files
 %defattr(-,root,root,-)
 %doc README.md
-%{_libexecdir}/docker/hooks.d/oci-registerMachine
-%{_mandir}/man1/oci-registerMachine.1.gz
+%{_libdir}/docker/hooks.d/oci-register-machine
+%{_mandir}/man1/oci-register-machine.1.gz
 
 %changelog
 * Tue Nov 03 2015 Sally O'Malley <somalley@redhat.com> - 1.0.0-1
-- package oci-registerMachine
+- package oci-register-machine


### PR DESCRIPTION
Standardize on oci-register-machine
Also move hooks package to install in /usr/lib/docker/hooks.d