### PR TITLE
Oci-register-machine should point to the container rootfs

### DIFF
--- a/oci-register-machine.go
+++ b/oci-register-machine.go
@@ -50,10 +50,7 @@ func RegisterMachine(name string, id string, pid int, root_directory string) err
 	if service == "" {
 		service = "runc"
 	}
-	/*	return obj.Call("org.freedesktop.machine1.Manager.RegisterMachine", 0, name[0:32], av, service, "container", uint32(pid), root_directory).Err
-	 */
-	return obj.Call("org.freedesktop.machine1.Manager.RegisterMachine", 0, name[0:32], av, service, "container", uint32(pid), "/").Err
-	return nil
+	return obj.Call("org.freedesktop.machine1.Manager.RegisterMachine", 0, name[0:32], av, service, "container", uint32(pid), root_directory).Err
 }
 
 // TerminateMachine registered with systemd on the host system


### PR DESCRIPTION
In order to get logs to show up in journalctl -M UUID outside
of the container, we need to put the journals into a directory
by themselves. journalct uses the ROOTFS flag under machinectl
to locate the files.  Setting the ROOTFS to /var/log/oci/container-journals/UUID
will allow us to store the logs under

/var/log/oci/container-journalc/UUID/var/log/journal

oci-systemd will point here for rootfs and journals will be available on host.