### PR TITLE
Update the documented location of the hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ tracks locally running virtual machines and containers and the processes belongi
 
 This project produces a golang binary that can be used with Docker (with minor code changes).
 If you clone this branch and build/install `register-machine.go`, a binary will be placed in
-`/usr/lib/docker/hooks.d` named `oci-register-machine`. You can change this location by
+`/usr/libexec/oci/hooks.d` named `oci-register-machine`. You can change this location by
 editing `HOOKSDIR` in the Makefile.
 
 


### PR DESCRIPTION
We moved the hooks from /usr/lib/docker/hooks.d to /usr/libexec/oci/hooks.d during the Fedora package review, so we need to catch the docs up.