### PR TITLE
Packaging .spec file: own %{_libexecdir}/oci

### DIFF
--- a/oci-register-machine.spec
+++ b/oci-register-machine.spec
@@ -150,6 +150,7 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/Godeps/_workspace:%{gopath}
 %files
 %license LICENSE
 %doc oci-register-machine.1.md README.md
+%dir /%{_libexecdir}/oci
 %dir /%{_libexecdir}/oci/hooks.d
 /%{_libexecdir}/oci/hooks.d/oci-register-machine
 %{_mandir}/man1/oci-register-machine.1*


### PR DESCRIPTION
We don't depend on anything that supplies the %{_libexecdir}/oci directory, so we should probably share it with other packages, like we probably will for %{_libexecdir}/oci/hooks.d.