### PR TITLE
Fix logging format

### DIFF
--- a/oci-register-machine.go
+++ b/oci-register-machine.go
@@ -78,7 +78,7 @@ func main() {
 		log.Fatalf("RegisterMachine Failed %v", err.Error())
 	}
 
-	log.Printf("Register machine: %s %d %s %s", command, state.ID, state.Pid, state.Root)
+	log.Printf("Register machine: %s %s %d %s", command, state.ID, state.Pid, state.Root)
 	// ensure id is a hex string at least 32 chars
 	passId, err := Validate(state.ID)
 	if err != nil {


### PR DESCRIPTION
Prior to this fix, you'd see something like this:

```
Register machine: prestart
%!d(string=7b687c0c73f3824e1bc0f8145621b54dd46768f0d24bbb02de1995895e12fa3c) %!s(int=7713) /var/lib/docker/devicemapper/mnt/6f9a36c0ab1a6dfeb991b51dbfc2f4636d31cfc71c346ce930ea6c42b396ab2a/rootfs
```