### PR TITLE
Allow a user to disable oci-register-machine

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ install: oci-register-machine oci-register-machine.1
 	install -m 755 oci-register-machine $(HOOKSINSTALLDIR)
 	install -d -m 755 $(PREFIX)/share/man/man1
 	install -m 644 oci-register-machine.1 $(PREFIX)/share/man/man1
+	install -m 644 oci-register-machine.conf $(DESTDIR)/etc/oci-register-machine.conf
 # Clean up
 #
 # Example:

--- a/oci-register-machine.1.md
+++ b/oci-register-machine.1.md
@@ -16,6 +16,8 @@ as a hook, runc will execute the application after the container process is crea
 After starting an OCI container, the container will be listed with the `machinectl`.  The machine name will be the container ID.  Machinectl will then be able
 to manage the container. When container exits, the oci-register-machine will remove the instance from machinectl.
 
+You can disable this service by editing the /etc/oci-register-machine.conf
+file and setting the disabled field to true.
 
 ## EXAMPLES
 


### PR DESCRIPTION
oci-register-machine can be considered an information leak for
certain container workloads.  It allows information about the container
to be viewed by non privileged users.  Some adinistrators may want to disable
containers reporting this information to systemd-machinectl.  We want this
package installed by default, and removing this package is not an option
on atomic host.

This patch adds a /etc/oci-register-machine.conf which contains a json
data to disable the tool.