### PR TITLE
prepend previously set $GOPATH values in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ GOBUILD=go build -a -ldflags "${LDFLAGS:-} -B 0x$(shell head -c20 /dev/urandom|o
 # Example:
 #   make build
 oci-register-machine: oci-register-machine.go
-	GOPATH=/usr/share/gocode $(GOBUILD) -o oci-register-machine
+	GOPATH=$GOPATH:/usr/share/gocode $(GOBUILD) -o oci-register-machine
 
 oci-register-machine.1: oci-register-machine.1.md
 	go-md2man -in "oci-register-machine.1.md" -out "oci-register-machine.1"


### PR DESCRIPTION
rpm build process sets $GOPATH in the spec file to use or skip bundled
libraries. Makefile should include these to make rpmbuild go
smoothly.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>