### PR TITLE
oci-register-machine will not terminate containers with ID > 32 chars

### DIFF
--- a/oci-register-machine.go
+++ b/oci-register-machine.go
@@ -5,12 +5,12 @@ package main
 import (
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"log/syslog"
 	"os"
 	"strings"
-	"fmt"
 
 	"github.com/godbus/dbus"
 	"gopkg.in/yaml.v1"
@@ -27,11 +27,11 @@ type State struct {
 }
 
 type Process struct {
-	Env     []string       `json:"env"`
+	Env []string `json:"env"`
 }
 
 type Config struct {
-	Process    *Process `json:"process"`
+	Process *Process `json:"process"`
 }
 
 func Validate(id string) (string, error) {
@@ -79,6 +79,10 @@ func TerminateMachine(name string) error {
 			return err
 		}
 	}
+	if len(name) > 32 {
+		name = name[0:32]
+	}
+
 	obj := conn.Object("org.freedesktop.machine1", "/org/freedesktop/machine1")
 	return obj.Call("org.freedesktop.machine1.Manager.TerminateMachine", 0, name).Err
 }
@@ -143,11 +147,9 @@ func main() {
 		}
 	}
 	// ensure id is a hex string at least 32 chars
-	if len(passId) < 32 {
-		passId, err = Validate(passId)
-		if err != nil {
-			log.Fatalf("RegisterMachine Failed %v", err.Error())
-		}
+	passId, err = Validate(passId)
+	if err != nil {
+		log.Fatalf("RegisterMachine Failed %v", err.Error())
 	}
 
 	switch command {

--- a/oci-register-machine.go
+++ b/oci-register-machine.go
@@ -105,11 +105,11 @@ func main() {
 	data, err := ioutil.ReadFile(CONFIG)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			log.Fatalf("RegisterMachine Failed to read %s %v", CONFIG, err.Error())
+			log.Fatalf("RegisterMachine Failed to read %s %m", CONFIG)
 		}
 	} else {
 		if err := yaml.Unmarshal(data, &settings); err != nil {
-			log.Fatalf("RegisterMachine Failed to parse %s %v", CONFIG, err.Error())
+			log.Fatalf("RegisterMachine Failed to parse %s %m", CONFIG)
 		}
 		if settings.Disabled {
 			return
@@ -117,7 +117,7 @@ func main() {
 	}
 
 	if err := json.NewDecoder(os.Stdin).Decode(&state); err != nil {
-		log.Fatalf("RegisterMachine Failed %v", err.Error())
+		log.Fatalf("RegisterMachine Failed %m")
 	}
 
 	command := map[bool]string{true: "prestart", false: "poststop"}[state.Pid > 0]
@@ -133,10 +133,10 @@ func main() {
 		configFile := fmt.Sprintf("%s/config.json", state.BundlePath)
 		data, err := ioutil.ReadFile(configFile)
 		if err != nil {
-			log.Fatalf("RegisterMachine Failed to read %s %v", configFile, err.Error())
+			log.Fatalf("RegisterMachine Failed to read %s %m", configFile)
 		}
 		if err := yaml.Unmarshal(data, &config); err != nil {
-			log.Fatalf("RegisterMachine Failed to parse %s %v", configFile, err.Error())
+			log.Fatalf("RegisterMachine Failed to parse %s %m", configFile)
 		}
 		for _, env := range config.Process.Env {
 			const PREFIX = "container_uuid="
@@ -149,14 +149,14 @@ func main() {
 	// ensure id is a hex string at least 32 chars
 	passId, err = Validate(passId)
 	if err != nil {
-		log.Fatalf("RegisterMachine Failed %v", err.Error())
+		log.Fatalf("RegisterMachine Failed %m")
 	}
 
 	switch command {
 	case "prestart":
 		{
 			if err = RegisterMachine(state.ID, passId, int(state.Pid), state.Root); err != nil {
-				log.Fatalf("Register machine failed: %v", err)
+				log.Fatalf("Register machine failed: %m")
 			}
 			return
 		}
@@ -164,7 +164,7 @@ func main() {
 		{
 			if err := TerminateMachine(state.ID); err != nil {
 				if !strings.Contains(err.Error(), "No machine") {
-					log.Fatalf("TerminateMachine failed: %v", err)
+					log.Fatalf("TerminateMachine failed: %m")
 				}
 			}
 			return


### PR DESCRIPTION
This patch truncates the ID the same way in Terminate as it does in
register.