### PR TITLE
Add support for new containers oci configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ all: build docs
 PREFIX ?= $(DESTDIR)/usr
 HOOKSDIR=/usr/libexec/oci/hooks.d
 HOOKSINSTALLDIR=$(DESTDIR)$(HOOKSDIR)
+HOOKSJSONDIR=${DESTDIR}/usr/share/containers/oci/hooks.d
+
 # need this substitution to get build ID note
 GOBUILD=go build -a -ldflags "${LDFLAGS:-} -B 0x$(shell head -c20 /dev/urandom|od -An -tx1|tr -d ' \n')"
 
@@ -48,6 +50,8 @@ install: oci-register-machine oci-register-machine.1
 	install -d -m 755 $(PREFIX)/share/man/man1
 	install -m 644 oci-register-machine.1 $(PREFIX)/share/man/man1
 	install -D -m 644 oci-register-machine.conf $(DESTDIR)/etc/oci-register-machine.conf
+	install -d -m 755 $(HOOKSJSONDIR)
+	install -m 644 oci-register-machine.json $(HOOKSJSONDIR)
 # Clean up
 #
 # Example:

--- a/oci-register-machine.json
+++ b/oci-register-machine.json
@@ -1,0 +1,5 @@
+{
+    "cmd": [".*/init$" , ".*/systemd$" ],
+    "hook": "/usr/libexec/oci/hooks.d/oci-register-machine",
+    "stages": [ "prestart", "poststop" ]
+}

--- a/oci-register-machine.spec
+++ b/oci-register-machine.spec
@@ -154,6 +154,8 @@ export GOPATH=%{buildroot}/%{gopath}:$(pwd)/Godeps/_workspace:%{gopath}
 %dir /%{_libexecdir}/oci/hooks.d
 /%{_libexecdir}/oci/hooks.d/oci-register-machine
 %{_mandir}/man1/oci-register-machine.1*
+%dir %{_usr}/share/containers/oci/hooks.d
+%{_usr}/share/containers/oci/hooks.d/oci-register-machine.json
 
 %if 0%{?with_devel}
 %files devel -f devel.file-list


### PR DESCRIPTION
The oci-register-machine.json file tells container runtimes:
- Whether to run the plugin at all
- Which stage to run the plugin
- Path to the plugin.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>