### PR TITLE
Disable this hook by default.

### DIFF
--- a/oci-register-machine.conf
+++ b/oci-register-machine.conf
@@ -1,2 +1,2 @@
 # Disable oci-register-machine by setting the disabled field to true
-disabled : false
+disabled : true


### PR DESCRIPTION
We also want to make this hook optional to install.

Very few people are taking advantage of it, and it seems to be
causing more issues then it is worth.

For CRI-O we are only using it with oci-systemd-hook, which is probably
a better long term solution.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>